### PR TITLE
Fix build script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,10 @@ var chalk = require('chalk');
 
 var babelify = require('babelify');
 
-var uglify = require('gulp-uglify');
+var uglify = require('uglify-es');
+var composer = require('gulp-uglify/composer');
+var minify = composer(uglify, console);
+
 var buffer = require('vinyl-buffer');
 
 
@@ -86,7 +89,7 @@ gulp.task('browserify-minified', ['manifest'], function() {
             })
             .pipe(source('bundle.js'))
             .pipe(buffer())
-            .pipe(uglify())
+            .pipe(minify())
             .pipe(gulp.dest('src/js/dist'));
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jira-improved",
   "description": "Chrome plugin for improving Jira Kanban and Agile views.",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "scripts": {
     "start": "gulp",
     "test": "gulp test",
@@ -58,6 +58,7 @@
     "gulp-zip": "^4.0.0",
     "jshint": "^2.9.5",
     "jshint-stylish": "^2.2.1",
+    "uglify-es": "^3.1.3",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.9.0"


### PR DESCRIPTION
I was able to use `pump` instead of pipes to get more details on the real error during all of the streaming. Uglify doesn't support minifying ES6. I am not familiar with Browserify, but I think it is pulling in node libraries that have `const` in them, and it isn't transforming those with babel, just the source code. Maybe an older version of browserify or maybe node(?) would allow this build to work without this patch.

Since we are building a chrome extension, const and other ES6 is fine to leave in the production code. uglify-es is now used for minification. It handles ES6.